### PR TITLE
Fix where previous song would play on skip/stop

### DIFF
--- a/src/lib/classes/queue.js
+++ b/src/lib/classes/queue.js
@@ -180,6 +180,7 @@ module.exports = class queue extends EventEmitter {
         if (/youtu(\.?)be/.test(track.url)) {
             res = await createAudioResource(ytdl(track.url, {
                 filter: 'audioonly',
+                highWaterMark: 10485760,
                 dlChunkSize: 0
             }), {inlineVolume: this.volume !== 1});
         } else {

--- a/src/lib/classes/queue.js
+++ b/src/lib/classes/queue.js
@@ -149,7 +149,7 @@ module.exports = class queue extends EventEmitter {
                     } catch (e) {
                         this.emit(EVT_ERROR, this.textChannel, e)
                     }
-                    if (this.tracks[0]) this.play(track)
+                    if (this.tracks[0]) this.play(this.tracks[0])
                     else {
                         setTimeout(() => {
                             if (!this.tracks[0]) return this.leave()


### PR DESCRIPTION
It was previously playing the track that is passed in to play instead of the next one in the queue when a song finishes via it ending or a skip/stop.

Also added a fix for ytdl erroring due to insufficient buffer on certain tracks